### PR TITLE
Fix stray csproj.user file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ appsettings.json
 *.pubxml.user
 *.pubxml
 *.publishproj
+
+# Visual Studio user-specific project files should not be committed
+*.csproj.user

--- a/LibroFlow/LibroFlow.csproj.user
+++ b/LibroFlow/LibroFlow.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
## Summary
- remove user-specific `csproj.user` file
- ignore these user-specific settings in `.gitignore`

## Testing
- `dotnet build LibroFlow.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415baefd388326b08dbc73b5473680